### PR TITLE
Allow parsing of single resource objects.

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -123,8 +123,13 @@ module.exports = function(object) {
 		return result;
 	}, {});
 
+	if(object.data instanceof Array) {
+		return {
+			data :	object.data.map(partial(parseResource, included))
+		}
+	}
 	return {
-		data :	object.data.map(partial(parseResource, included))
+		data: partial(parseResource, included)(object.data);	
 	}
 };
 


### PR DESCRIPTION
http://jsonapi.org/format/#document-top-level

```
Primary data MUST be either:

a single resource object, a single resource identifier object, or null, for requests that target single resources
an array of resource objects, an array of resource identifier objects, or an empty array ([]), for requests that target resource collections
```

The data object may not be an array of resource objects, but a single resource object.

You may need to test the change ;)
